### PR TITLE
GLM-6475 - Security > Add gemlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 pkg
 doc
-Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,75 @@
+PATH
+  remote: .
+  specs:
+    bitly (1.1.2)
+      httparty (>= 0.7.6)
+      multi_json (~> 1.3)
+      oauth2 (>= 0.5.0, < 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    concurrent-ruby (1.2.2)
+    crack (0.4.5)
+      rexml
+    faraday (2.7.9)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    flexmock (2.3.6)
+    hashdiff (1.0.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    jwt (2.7.1)
+    mini_mime (1.1.2)
+    minitest (5.8.5)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    oauth2 (1.4.11)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+    public_suffix (5.0.1)
+    rack (3.0.8)
+    rake (13.0.6)
+    rexml (3.2.5)
+    ruby2_keywords (0.0.5)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.2)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bitly!
+  bundler (~> 2.1)
+  flexmock
+  minitest (~> 5.8.3)
+  rake
+  shoulda (~> 3.5.0)
+  webmock
+
+BUNDLED WITH
+   2.1.4

--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "oauth2", "< 2.0", ">= 0.5.0"
   spec.add_runtime_dependency "rack", "<2" if RUBY_VERSION.to_f < 2.2
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "shoulda", "~> 3.5.0"
   spec.add_development_dependency "flexmock"


### PR DESCRIPTION
Dependabot wants us to bump Bundler and add a Gemlock file. This patch does that. Details: https://github.com/Crowd9/bitly/security/dependabot/4